### PR TITLE
fix guest user cannot open linked search in web form child table field

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -415,7 +415,7 @@ def is_document_amended(doctype, docname):
 	return False
 
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
 def validate_link(doctype: str, docname: str, fields=None):
 	if not isinstance(doctype, str):
 		frappe.throw(_("DocType must be a string"))

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -33,7 +33,7 @@ class LinkSearchResults(TypedDict):
 
 
 # this is called by the Link Field
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
 def search_link(
 	doctype: str,
 	txt: str,

--- a/frappe/search/website_search.py
+++ b/frappe/search/website_search.py
@@ -46,7 +46,7 @@ class WebsiteSearch(FullTextSearch):
 
 		print()
 
-		return self.get_items_to_index()
+		return self._items_to_index
 
 	def get_document_to_index(self, route: str) -> frappe._dict | None:
 		"""Render a page and parse it using `BeautifulSoup`.

--- a/frappe/search/website_search.py
+++ b/frappe/search/website_search.py
@@ -44,7 +44,6 @@ class WebsiteSearch(FullTextSearch):
 			update_progress_bar("Retrieving Routes", i, len(routes))
 			self._items_to_index += [self.get_document_to_index(route)]
 
-		print()
 
 		return self._items_to_index
 


### PR DESCRIPTION
when creating web forms and added a child table
when guest (not logged in) user try to fill the child table, "You are not permitted to access this resource"

frappe.exceptions.PermissionError: You are not permitted to access this resource.Function frappe.desk.search.search_link is not whitelisted.

fix to this issue:
https://github.com/frappe/frappe/issues/27567#issue-2496269047

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
