### PR TITLE
fix(quick_list_widget) workflow_state not showing when exist

### DIFF
--- a/frappe/public/js/frappe/widgets/quick_list_widget.js
+++ b/frappe/public/js/frappe/widgets/quick_list_widget.js
@@ -199,12 +199,9 @@ export default class QuickListWidget extends Widget {
 				fields.push("docstatus");
 			}
 
-			this.has_workflow_state = frappe.meta.has_field(this.document_type, "workflow_state");
-			if(this.has_workflow_state){
-				// add workflow state field if workflow exist & is active
-				let workflow_fieldname = frappe.workflow.get_state_fieldname(this.document_type);
+			let workflow_fieldname = frappe.workflow.get_state_fieldname(this.document_type);
+			if(workflow_fieldname){
 				workflow_fieldname && fields.push(workflow_fieldname);
-				fields.push("workflow_state");
 			}
 
 			fields.push("modified");

--- a/frappe/public/js/frappe/widgets/quick_list_widget.js
+++ b/frappe/public/js/frappe/widgets/quick_list_widget.js
@@ -197,10 +197,14 @@ export default class QuickListWidget extends Widget {
 			if (this.has_status_field) {
 				fields.push("status");
 				fields.push("docstatus");
+			}
 
+			this.has_workflow_state = frappe.meta.has_field(this.document_type, "workflow_state");
+			if(this.has_workflow_state){
 				// add workflow state field if workflow exist & is active
 				let workflow_fieldname = frappe.workflow.get_state_fieldname(this.document_type);
 				workflow_fieldname && fields.push(workflow_fieldname);
+				fields.push("workflow_state");
 			}
 
 			fields.push("modified");

--- a/frappe/search/website_search.py
+++ b/frappe/search/website_search.py
@@ -46,7 +46,7 @@ class WebsiteSearch(FullTextSearch):
 
 		print()
 
-		return self.get_items_to_index()
+		return self._items_to_index
 
 	def get_document_to_index(self, route: str) -> frappe._dict | None:
 		"""Render a page and parse it using `BeautifulSoup`.

--- a/frappe/search/website_search.py
+++ b/frappe/search/website_search.py
@@ -44,7 +44,6 @@ class WebsiteSearch(FullTextSearch):
 			update_progress_bar("Retrieving Routes", i, len(routes))
 			self._items_to_index += [self.get_document_to_index(route)]
 
-		print()
 
 		return self._items_to_index
 


### PR DESCRIPTION
when a document has workflow state, it should show workflow_status. Instead it doesn't.

existing code put a validation if status exist, but a document cam have a workflow_state without a "status" field.

the correct approach is to separate the logic.
prev code:

`.

			// check doctype has status field
			this.has_status_field = frappe.meta.has_field(this.document_type, "status");

			if (this.has_status_field) {
				fields.push("status");
				fields.push("docstatus");

				// add workflow state field if workflow exist & is active
				let workflow_fieldname = frappe.workflow.get_state_fieldname(this.document_type);
				workflow_fieldname && fields.push(workflow_fieldname);
			}`
			

after fixing the logic the "workflow_state" showed up :)
![image](https://github.com/user-attachments/assets/12703249-aead-4c68-8e10-b99da043042c)


<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
