### PR TITLE
fix(quick_list_widget):workflow-status-not-showing

### DIFF
--- a/frappe/public/js/frappe/widgets/quick_list_widget.js
+++ b/frappe/public/js/frappe/widgets/quick_list_widget.js
@@ -197,12 +197,13 @@ export default class QuickListWidget extends Widget {
 			if (this.has_status_field) {
 				fields.push("status");
 				fields.push("docstatus");
-
-				// add workflow state field if workflow exist & is active
-				let workflow_fieldname = frappe.workflow.get_state_fieldname(this.document_type);
+			}
+			// add workflow state field if workflow exist & is active
+			let workflow_fieldname = frappe.workflow.get_state_fieldname(this.document_type);
+			if(workflow_fieldname){
 				workflow_fieldname && fields.push(workflow_fieldname);
 			}
-
+			
 			fields.push("modified");
 
 			let quick_list_filter = frappe.utils.process_filter_expression(this.quick_list_filter);


### PR DESCRIPTION
when a document has workflow state, it should show workflow_status. Instead it doesn't.

existing code put a validation if "status" field exist, but a document can have a workflow_state without a "status" field.

the correct approach is to separate the logic.

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
