### PR TITLE
fix(response):private-files-attachments-still-accessible-despite-no-p…

### DIFF
--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -272,8 +272,12 @@ def download_backup(path):
 def download_private_file(path: str) -> Response:
 	"""Checks permissions and sends back private file"""
 	from frappe.core.doctype.file.utils import find_file_by_url
-
-	if frappe.session.user == "Guest":
+	
+	""" (checks if the user has permission to access the document in at least one document containing the attached file)"""
+	doctypes = frappe.get_all("File", filters={"file_url":path}, fields="attached_to_doctype", pluck="attached_to_doctype")
+	has_permission_allowed = any([frappe.has_permission(doctype, "read") for doctype in doctypes ])
+	
+	if frappe.session.user == "Guest" or not has_permission_allowed:
 		raise Forbidden(_("You don't have permission to access this file"))
 
 	file = find_file_by_url(path, name=frappe.form_dict.fid)


### PR DESCRIPTION
fix to this issue : private_files accessible to all user despite permission control

this is a fix to this issue:
https://github.com/frappe/frappe/issues/28086

### Expected result
after this fix
1. Directory /private/files/ will return nothing if the user has no permission
2. Public files will still be accessible (preserve the behavior before the fix for public files)

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 3. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 4. All tests pass locally, UI and Unit tests
 5. All business logic and validations must be on the server-side
 6. Update necessary Documentation
 7. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->
